### PR TITLE
Slick methods exposed

### DIFF
--- a/dist/slick.js
+++ b/dist/slick.js
@@ -49,7 +49,8 @@ angular.module('slick', []).directive('slick', [
         variableWidth: '@',
         vertical: '@',
         prevArrow: '@',
-        nextArrow: '@'
+        nextArrow: '@',
+        control: '@'
       },
       link: function (scope, element, attrs) {
         var destroySlick, initializeSlick, isInitialized;
@@ -64,8 +65,9 @@ angular.module('slick', []).directive('slick', [
         };
         initializeSlick = function () {
           return $timeout(function () {
-            var currentIndex, slider;
-            slider = $(element);
+            var currentIndex, 
+                slider = $(element)
+                methods = ['slickGoTo', 'slickNext', 'slickPrev', 'slickPause', 'slickPlay', 'slickAdd', 'slickRemove', 'slickFilter', 'slickUnfilter', 'unslick'];
             if (scope.currentIndex != null) {
               currentIndex = scope.currentIndex;
             }
@@ -129,6 +131,16 @@ angular.module('slick', []).directive('slick', [
               prevArrow: scope.prevArrow ? $(scope.prevArrow) : void 0,
               nextArrow: scope.nextArrow ? $(scope.nextArrow) : void 0
             });
+            if (scope.control) {
+              scope.$parent[scope.control] = {};
+              methods.forEach(function (value) {
+                scope.$parent[scope.control][value] = function () {
+                  var args = Array.prototype.slice.call(arguments);
+                  args.unshift(value);
+                  slider.slick.apply(element, args);
+                };
+              });
+            }
             return scope.$watch('currentIndex', function (newVal, oldVal) {
               if (currentIndex != null && newVal != null && newVal !== currentIndex) {
                 return slider.slickGoTo(newVal);


### PR DESCRIPTION
A slick control object that contains the methods documented at https://github.com/kenwheeler/slick#methods is now available to the controller scope by setting a control="mySlickControlName" or data-contol="mySlickControlName" attribute.
```html
<slick data-dots="true" data-speed="300" data-slides-to-show="3" data-slides-to-scroll="1" data-control="slickControl"></slick>

<button data-ng-click="slickControl.slickPrev()">Prev Method</button>
<button data-ng-click="slickControl.slickGoTo(5)">Go To Method</button>
<button data-ng-click="slickControl.slickNext()">Next Method</button>
```
```javascript
$scope.slickControl.slickGoTo(5)
```